### PR TITLE
update fedora33 image hash

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,7 +93,7 @@ http_archive(
 # Pull base image fedora33
 container_pull(
     name = "fedora",
-    digest = "sha256:bfcc10d2d2a3a52fe997daba311c3a5298b426b524ab2b012fa24730dd0eb763",
+    digest = "sha256:59a4488599eb5c28cfc1695c4d9956fb2734a08be94d86269375cb68fc3c2406",
     registry = "quay.io",
     repository = "fedora/fedora",
     tag = "33-x86_64",


### PR DESCRIPTION
Signed-off-by: Prashanth Buddhala <pbuds@cisco.com>

update Fedora33 image hash as the older image is not longer available.

