### PR TITLE
cloner_startup.sh: use bash instead of sh

### DIFF
--- a/cmd/cdi-cloner/cloner_startup.sh
+++ b/cmd/cdi-cloner/cloner_startup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #Copyright 2018 The CDI Authors.
 #


### PR DESCRIPTION
"set -euo pipefail" is technically a bash option, not an sh option.
It causes a failure on Linux distros where /bin/sh is not a sym link
to /bin/bash -- e.g., Ubuntu 20, where /bin/sh is a sym link to
/bin/dash).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>